### PR TITLE
Use physical-layout instead of matrix-transform.

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -13,7 +13,7 @@
 
 / {
     chosen {
-      zmk,matrix_transform = &five_column_transform;
+        zmk,physical-layout = &foostan_corne_5col_layout;
     };
 
     behaviors {


### PR DESCRIPTION
Fixes #3 

Update 5-column Corne keymap to use `physical-layout` which is preferred since it allows using ZMK Studio.